### PR TITLE
Fix fallback to system locale

### DIFF
--- a/webapp-springboot-thymeleaf/doc/README-06-Internationalisation.md
+++ b/webapp-springboot-thymeleaf/doc/README-06-Internationalisation.md
@@ -33,7 +33,17 @@ spring.messages.fallback-to-system-locale=true # Whether to fall back to the sys
 spring.messages.use-code-as-default-message=false # Whether to use the message code as the default message instead of throwing a "NoSuchMessageException". Recommended during development only.
 ```
 
-We rely on the defaults. So no configuration in `application.yml` is needed.
+We rely on the defaults, except for `spring.messages.fallback-to-system-locale`.
+This variable needs to be changed to `false`, because a fallback to the default
+language (in our example to `messages.properties`) won't work when the system
+locale is set to German. Thus, the following property needs to be added to
+`application.yml`:
+
+```yaml
+spring:
+  messages:
+    fallback-to-system-locale: false
+```
 
 We do not provide one properties file per template but use the above mentioned global messages-properties files.
 We have to provide a default file `messages.properties` containing translations of a default language (we chose english translation...),

--- a/webapp-springboot-thymeleaf/step06/src/main/resources/application.yml
+++ b/webapp-springboot-thymeleaf/step06/src/main/resources/application.yml
@@ -24,6 +24,8 @@ server:
     context-path: "/"
 
 spring:
+  messages:
+    fallback-to-system-locale: false
   profiles:
     active: local
   security:

--- a/webapp-springboot-thymeleaf/step07/src/main/resources/application.yml
+++ b/webapp-springboot-thymeleaf/step07/src/main/resources/application.yml
@@ -27,6 +27,8 @@ server:
     context-path: "/"
 
 spring:
+  messages:
+    fallback-to-system-locale: false
   profiles:
     active: local
   security:

--- a/webapp-springboot-thymeleaf/step08/src/main/resources/application.yml
+++ b/webapp-springboot-thymeleaf/step08/src/main/resources/application.yml
@@ -27,6 +27,8 @@ server:
     context-path: "/"
 
 spring:
+  messages:
+    fallback-to-system-locale: false
   profiles:
     active: local
   security:

--- a/webapp-springboot-thymeleaf/step09/src/main/resources/application.yml
+++ b/webapp-springboot-thymeleaf/step09/src/main/resources/application.yml
@@ -27,6 +27,8 @@ server:
     context-path: "/"
 
 spring:
+  messages:
+    fallback-to-system-locale: false
   profiles:
     active: local
   security:

--- a/webapp-springboot-thymeleaf/step10/src/main/resources/application.yml
+++ b/webapp-springboot-thymeleaf/step10/src/main/resources/application.yml
@@ -27,6 +27,8 @@ server:
     context-path: "/"
 
 spring:
+  messages:
+    fallback-to-system-locale: false
   profiles:
     active: local
   security:


### PR DESCRIPTION
This PR disables a fallback to system locale in spring messages.

This fixes the following bug: 

English is used as fallback language (messages are defines in `messages.properties`) in our applications. By default the `fallback-to-system-locale` in spring messages is set to `true`. When the system locale is set to German, then the fallback language (`messages.properties`) is NOT used - instead the German messages file (`messages_de.properties) is read.