### PR TITLE
Enable git plugin

### DIFF
--- a/webapp-springboot-thymeleaf/doc/README-03-Application_information.md
+++ b/webapp-springboot-thymeleaf/doc/README-03-Application_information.md
@@ -197,32 +197,111 @@ info:
 
 (Finally we deleted the lines...)
 
-### TODO: Add Git information
+### Add Git information
 
-The following section is not complete. Git information file git.properties is not generated...
-
-As we manage our sourcecode with Git, we can also include Git informations to the application infos.
-See
+As we manage our sourcecode with Git, we can also include Git informations to 
+the application infos. See
 
 * <https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-application-info-git>
 * <https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-git-info>
+* <https://github.com/ktoso/maven-git-commit-id-plugin>
 
-#### `pom.xml`
+#### Configuration
+
+The following options for configuring the Git plugin needs to added in `pom.xml`:
 
 ```xml
 <plugin>
   <groupId>pl.project13.maven</groupId>
   <artifactId>git-commit-id-plugin</artifactId>
   <version>2.2.5</version>
+  <executions>
+    <execution>
+      <id>get-the-git-infos</id>
+      <goals>
+        <goal>revision</goal>
+      </goals>
+    </execution>
+    <execution>
+      <id>validate-the-git-infos</id>
+      <goals>
+        <goal>validateRevision</goal>
+      </goals>
+    </execution>
+  </executions>
   <configuration>
-    <!--
-      If you'd like to tell the plugin where your .git directory is,
-      use this setting, otherwise we'll perform a search trying to
-      figure out the right directory. It's better to add it explicitly IMHO.
-    -->
     <dotGitDirectory>${project.basedir}/../../.git</dotGitDirectory>
+    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+    <verbose>true</verbose>
   </configuration>
 </plugin>
 ```
 
-TODO...
+To get complete information from Git, the following `actuator` info
+endpoint configuration for the Git plugin is needed:
+
+```yaml
+management:
+  info:
+    git:
+      mode: full
+```
+
+#### Output
+
+Then the Git plugin shows the following information under 
+<http://localhost:9001/monitoring/info>:
+
+```json
+{
+  "git":{
+    "tags":"",
+    "build":{
+      "version":"1.0.0-SNAPSHOT",
+      "user":{
+        "email":"firstname.lastname@bsb-muenchen.de",
+        "name":"Firstname Lastname"
+      },
+      "time":"2018-10-08T11:54:12Z",
+      "host":"user-power-workstation"
+    },
+    "total":{
+      "commit":{
+        "count":"123"
+      }
+    },
+    "commit":{
+      "time":"2018-10-05T11:20:44Z",
+      "user":{
+        "name":"Firstname Lastname",
+        "email":"firstname.lastname@bsb-muenchen.de"
+      },
+      "message":{
+        "full":"step06: recover files for step06",
+        "short":"step06: recover files for step06"
+      },
+      "id":{
+        "abbrev":"19bc580",
+        "describe-short":"19bc580-dirty",
+        "full":"19bc5806800fdf8f98f20f5ca8796058089a1e13",
+        "describe":"19bc580-dirty"
+      }
+    },
+    "branch":"recover-step06",
+    "closest":{
+      "tag":{
+        "name":"",
+        "commit":{
+          "count":""
+        }
+      }
+    },
+    "remote":{
+      "origin":{
+        "url":"https://github.com/dbmdz/blueprints.git"
+      }
+    },
+    "dirty":"true"
+  }
+}
+```

--- a/webapp-springboot-thymeleaf/doc/README-03-Application_information.md
+++ b/webapp-springboot-thymeleaf/doc/README-03-Application_information.md
@@ -232,7 +232,6 @@ The following options for configuring the Git plugin needs to added in `pom.xml`
   <configuration>
     <dotGitDirectory>${project.basedir}/../../.git</dotGitDirectory>
     <generateGitPropertiesFile>true</generateGitPropertiesFile>
-    <verbose>true</verbose>
   </configuration>
 </plugin>
 ```

--- a/webapp-springboot-thymeleaf/step03/pom.xml
+++ b/webapp-springboot-thymeleaf/step03/pom.xml
@@ -58,19 +58,6 @@
     </resources>
     <plugins>
       <plugin>
-        <groupId>pl.project13.maven</groupId>
-        <artifactId>git-commit-id-plugin</artifactId>
-        <version>2.2.5</version>
-        <configuration>
-          <!--
-              If you'd like to tell the plugin where your .git directory is,
-              use this setting, otherwise we'll perform a search trying to
-              figure out the right directory. It's better to add it explicitly IMHO.
-          -->
-          <dotGitDirectory>${project.basedir}/../../.git</dotGitDirectory>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
@@ -106,6 +93,30 @@
         </executions>
         <configuration>
           <classifier>exec</classifier>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <version>2.2.5</version>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>validate-the-git-infos</id>
+            <goals>
+              <goal>validateRevision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <dotGitDirectory>${project.basedir}/../../.git</dotGitDirectory>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+          <verbose>true</verbose>
         </configuration>
       </plugin>
     </plugins>

--- a/webapp-springboot-thymeleaf/step03/pom.xml
+++ b/webapp-springboot-thymeleaf/step03/pom.xml
@@ -116,7 +116,6 @@
         <configuration>
           <dotGitDirectory>${project.basedir}/../../.git</dotGitDirectory>
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
-          <verbose>true</verbose>
         </configuration>
       </plugin>
     </plugins>

--- a/webapp-springboot-thymeleaf/step03/src/main/resources/application.yml
+++ b/webapp-springboot-thymeleaf/step03/src/main/resources/application.yml
@@ -4,6 +4,7 @@ info:
     java:
       source: @maven.compiler.source@
       target: @maven.compiler.target@
+
 management:
   endpoint:
     health:
@@ -18,6 +19,7 @@ management:
       mode: full
   server:
     port: 9001
+
 spring:
   security:
     user:

--- a/webapp-springboot-thymeleaf/step03/src/main/resources/application.yml
+++ b/webapp-springboot-thymeleaf/step03/src/main/resources/application.yml
@@ -13,6 +13,9 @@ management:
       base-path: '/monitoring'
       exposure:
         include: "*"
+  info:
+    git:
+      mode: full
   server:
     port: 9001
 spring:

--- a/webapp-springboot-thymeleaf/step04/pom.xml
+++ b/webapp-springboot-thymeleaf/step04/pom.xml
@@ -95,6 +95,29 @@
           <classifier>exec</classifier>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <version>2.2.5</version>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>validate-the-git-infos</id>
+            <goals>
+              <goal>validateRevision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <dotGitDirectory>${project.basedir}/../../.git</dotGitDirectory>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/webapp-springboot-thymeleaf/step04/src/main/resources/application.yml
+++ b/webapp-springboot-thymeleaf/step04/src/main/resources/application.yml
@@ -14,6 +14,9 @@ management:
       base-path: '/monitoring'
       exposure:
         include: "*"
+  info:
+    git:
+      mode: full
   server:
     port: 9001
 

--- a/webapp-springboot-thymeleaf/step05/pom.xml
+++ b/webapp-springboot-thymeleaf/step05/pom.xml
@@ -112,6 +112,29 @@
           <classifier>exec</classifier>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <version>2.2.5</version>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>validate-the-git-infos</id>
+            <goals>
+              <goal>validateRevision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <dotGitDirectory>${project.basedir}/../../.git</dotGitDirectory>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/webapp-springboot-thymeleaf/step05/src/main/resources/application.yml
+++ b/webapp-springboot-thymeleaf/step05/src/main/resources/application.yml
@@ -14,6 +14,9 @@ management:
       base-path: '/monitoring'
       exposure:
         include: "*"
+  info:
+    git:
+      mode: full
   server:
     port: 9001
 

--- a/webapp-springboot-thymeleaf/step06/pom.xml
+++ b/webapp-springboot-thymeleaf/step06/pom.xml
@@ -112,6 +112,29 @@
           <classifier>exec</classifier>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <version>2.2.5</version>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>validate-the-git-infos</id>
+            <goals>
+              <goal>validateRevision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <dotGitDirectory>${project.basedir}/../../.git</dotGitDirectory>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/webapp-springboot-thymeleaf/step06/src/main/resources/application.yml
+++ b/webapp-springboot-thymeleaf/step06/src/main/resources/application.yml
@@ -14,6 +14,9 @@ management:
       base-path: '/monitoring'
       exposure:
         include: "*"
+  info:
+    git:
+      mode: full
   server:
     port: 9001
 

--- a/webapp-springboot-thymeleaf/step07/pom.xml
+++ b/webapp-springboot-thymeleaf/step07/pom.xml
@@ -112,6 +112,29 @@
           <classifier>exec</classifier>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <version>2.2.5</version>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>validate-the-git-infos</id>
+            <goals>
+              <goal>validateRevision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <dotGitDirectory>${project.basedir}/../../.git</dotGitDirectory>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/webapp-springboot-thymeleaf/step07/src/main/resources/application.yml
+++ b/webapp-springboot-thymeleaf/step07/src/main/resources/application.yml
@@ -14,6 +14,9 @@ management:
       base-path: '/monitoring'
       exposure:
         include: "*"
+  info:
+    git:
+      mode: full
   server:
     port: 9001
 

--- a/webapp-springboot-thymeleaf/step08/pom.xml
+++ b/webapp-springboot-thymeleaf/step08/pom.xml
@@ -112,6 +112,29 @@
           <classifier>exec</classifier>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <version>2.2.5</version>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>validate-the-git-infos</id>
+            <goals>
+              <goal>validateRevision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <dotGitDirectory>${project.basedir}/../../.git</dotGitDirectory>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/webapp-springboot-thymeleaf/step08/src/main/resources/application.yml
+++ b/webapp-springboot-thymeleaf/step08/src/main/resources/application.yml
@@ -14,6 +14,9 @@ management:
       base-path: '/monitoring'
       exposure:
         include: "*"
+  info:
+    git:
+      mode: full
   server:
     port: 9001
 

--- a/webapp-springboot-thymeleaf/step09/pom.xml
+++ b/webapp-springboot-thymeleaf/step09/pom.xml
@@ -125,6 +125,29 @@
           <classifier>exec</classifier>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <version>2.2.5</version>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>validate-the-git-infos</id>
+            <goals>
+              <goal>validateRevision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <dotGitDirectory>${project.basedir}/../../.git</dotGitDirectory>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/webapp-springboot-thymeleaf/step09/src/main/resources/application.yml
+++ b/webapp-springboot-thymeleaf/step09/src/main/resources/application.yml
@@ -14,6 +14,9 @@ management:
       base-path: '/monitoring'
       exposure:
         include: "*"
+  info:
+    git:
+      mode: full
   server:
     port: 9001
 

--- a/webapp-springboot-thymeleaf/step10/pom.xml
+++ b/webapp-springboot-thymeleaf/step10/pom.xml
@@ -157,6 +157,29 @@
           <classifier>exec</classifier>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <version>2.2.5</version>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>validate-the-git-infos</id>
+            <goals>
+              <goal>validateRevision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <dotGitDirectory>${project.basedir}/../../.git</dotGitDirectory>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/webapp-springboot-thymeleaf/step10/src/main/resources/application.yml
+++ b/webapp-springboot-thymeleaf/step10/src/main/resources/application.yml
@@ -14,6 +14,9 @@ management:
       base-path: '/monitoring'
       exposure:
         include: "*"
+  info:
+    git:
+      mode: full
   server:
     port: 9001
 


### PR DESCRIPTION
This PR adds a working configuration for the git version plugin.

Configuration is done in `pom.xml` and `application.yml` (`acutator endpoint).

Then various git-related stats are shown under <http://localhost:9001/monitoring/info>.

Configuration for git version plugin is first introduced in step 3 and is ported to the next steps with this PR.