### PR TITLE
Add OpenJDK 11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
   - oraclejdk8
+  - openjdk11
 services:
   - docker
 before_script:

--- a/blueprint-springmvc-thymeleaf-javaconfig-security-database/crud-hibernate-backend-impl-jpa/pom.xml
+++ b/blueprint-springmvc-thymeleaf-javaconfig-security-database/crud-hibernate-backend-impl-jpa/pom.xml
@@ -62,6 +62,10 @@
           </arguments>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.1</version>
+      </plugin>
     </plugins>
   </build>
   
@@ -80,8 +84,17 @@
       <artifactId>crud-hibernate-backend-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.2.11</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/blueprint-springmvc-thymeleaf-javaconfig-security-database/crud-hibernate-frontend-webapp/pom.xml
+++ b/blueprint-springmvc-thymeleaf-javaconfig-security-database/crud-hibernate-frontend-webapp/pom.xml
@@ -69,6 +69,10 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.1</version>
+      </plugin>
     </plugins>
   </build>
 
@@ -126,6 +130,31 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-surefire-provider</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/blueprint-springmvc-thymeleaf-javaconfig-security-database/pom.xml
+++ b/blueprint-springmvc-thymeleaf-javaconfig-security-database/pom.xml
@@ -62,6 +62,9 @@
     <version.hibernate-validator>5.3.6.Final</version.hibernate-validator>
     <version.jackson-annotations>2.9.7</version.jackson-annotations>
     <version.jackson-databind>2.9.7</version.jackson-databind>
+    <version.javax.annotation-api>1.3.2</version.javax.annotation-api>
+    <version.junit5>5.3.1</version.junit5>
+    <version.junit5-platform>1.3.1</version.junit5-platform>
     <version.junit>4.12</version.junit>
     <version.mockito-core>1.10.19</version.mockito-core>
     <version.postgresql>9.4-1201-jdbc4</version.postgresql>
@@ -83,6 +86,7 @@
     <version.doxia-module-markdown>1.6</version.doxia-module-markdown>
     <version.exec-maven-plugin>1.4.0</version.exec-maven-plugin>
     <version.jetty-maven-plugin>9.3.0.M2</version.jetty-maven-plugin>
+
     <version.lesscss-maven-plugin>1.7.0.1.1</version.lesscss-maven-plugin>
     <version.maven-compiler-plugin>3.1</version.maven-compiler-plugin>
     <version.maven-project-info-reports-plugin>2.4</version.maven-project-info-reports-plugin>
@@ -223,6 +227,11 @@
         <version>${version.digitalcollections.crud}</version>
       </dependency>
       <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>${version.javax.annotation-api}</version>
+      </dependency>
+      <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
         <version>${version.servlet-api}</version>
@@ -273,6 +282,36 @@
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-validator</artifactId>
         <version>${version.hibernate-validator}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>${version.junit5}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>${version.junit5}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-engine</artifactId>
+        <version>${version.junit5-platform}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-launcher</artifactId>
+        <version>${version.junit5-platform}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-surefire-provider</artifactId>
+        <version>${version.junit5-platform}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     
     <version.slf4j-api>1.7.22</version.slf4j-api>
-    <version.jacoco-maven-plugin>0.7.9</version.jacoco-maven-plugin>
-    <version.maven-javadoc-plugin>2.10.4</version.maven-javadoc-plugin>
+    <version.jacoco-maven-plugin>0.8.2</version.jacoco-maven-plugin>
+    <version.maven-javadoc-plugin>3.0.1</version.maven-javadoc-plugin>
     <version.maven-source-plugin>3.0.1</version.maven-source-plugin>
     <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
     <version.versions-maven-plugin>2.4</version.versions-maven-plugin>

--- a/rest-webservice/rest-integration-tests/pom.xml
+++ b/rest-webservice/rest-integration-tests/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <junit.version>4.12</junit.version>
     <feign.version>9.5.0</feign.version>
-    <testcontainers.version>1.3.0</testcontainers.version>
+    <testcontainers.version>1.10.1</testcontainers.version>
     <assertj-core.version>3.8.0</assertj-core.version>
   </properties>
 

--- a/springmvc-thymeleaf/pom.xml
+++ b/springmvc-thymeleaf/pom.xml
@@ -18,6 +18,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <version.junit>4.12</version.junit>
+    <version.maven-war-plugin>3.2.2</version.maven-war-plugin>
     <version.servlet-api>3.1.0</version.servlet-api>
     <version.slf4j>1.7.22</version.slf4j>
     <version.spring>5.1.1.RELEASE</version.spring>
@@ -97,12 +98,12 @@
             <include>**/*Tests.java</include>
           </includes>
         </configuration>
-        <version>2.18.1</version>
+        <version>2.22.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.6</version>
+        <version>${version.maven-war-plugin}</version>
         <configuration>
           <failOnMissingWebXml>false</failOnMissingWebXml>
         </configuration>


### PR DESCRIPTION
This PR adds openjdk11 to Travis CI configuration, updates various dependencies and introduces some fixes that are needed with OpenJDK 11.