### PR TITLE
Security alert: update version of jackson

### DIFF
--- a/blueprint-springmvc-thymeleaf-javaconfig-security-database/pom.xml
+++ b/blueprint-springmvc-thymeleaf-javaconfig-security-database/pom.xml
@@ -61,8 +61,7 @@
     <version.hamcrest-all>1.3</version.hamcrest-all>
     <version.hibernate-entitymanager>5.3.7.Final</version.hibernate-entitymanager>
     <version.hibernate-validator>6.0.13.Final</version.hibernate-validator>
-    <version.jackson-annotations>2.9.7</version.jackson-annotations>
-    <version.jackson-databind>2.9.7</version.jackson-databind>
+    <version.jackson>2.9.8</version.jackson>
     <version.javax.annotation-api>1.3.2</version.javax.annotation-api>
     <version.junit5>5.3.2</version.junit5>
     <version.mockito-core>2.23.4</version.mockito-core>
@@ -194,12 +193,12 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>${version.jackson-annotations}</version>
+        <version>${version.jackson}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${version.jackson-databind}</version>
+        <version>${version.jackson}</version>
       </dependency>
       <dependency>
         <groupId>com.github.mxab.thymeleaf.extras</groupId>


### PR DESCRIPTION
This PR updates the version of `jackson` to fix CVE-2018-19360, CVE-2018-19362 and CVE-2018-19361.

This was found during a GitHub Security Scan.