### PR TITLE
docker: use latest maven dockerfile with openjdk11

### DIFF
--- a/rest-webservice/rest-integration-tests/pom.xml
+++ b/rest-webservice/rest-integration-tests/pom.xml
@@ -18,7 +18,7 @@
 
     <version.assertj-core>3.8.0</version.assertj-core>
     <version.logback-classic>1.2.3</version.logback-classic>
-    <version.testcontainers>1.10.2</version.testcontainers>
+    <version.testcontainers>1.10.5</version.testcontainers>
   </properties>
 
   <dependencies>

--- a/rest-webservice/rest-server-springboot/Dockerfile
+++ b/rest-webservice/rest-server-springboot/Dockerfile
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-oraclejdk8:slim
+FROM maven:3.6.0-jdk-11-slim
 
 EXPOSE 9000
 EXPOSE 9001


### PR DESCRIPTION
Previously, the rest integration tests were run inside an Ubuntu 15 (!) container with OracleJDK.

With this PR a latest Maven image with OpenJDK 11 is used for executing integration tests.