### PR TITLE
Use Spring Boot starter dependencies as parent 

### DIFF
--- a/console-application-springboot/step01/pom.xml
+++ b/console-application-springboot/step01/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.1.RELEASE</version>
+    <version>2.1.2.RELEASE</version>
   </parent>
 
   <name>DigitalCollections: Blueprints 5: Application (Spring Boot + Commandline) (Step 01)</name>

--- a/console-application-springboot/step02/pom.xml
+++ b/console-application-springboot/step02/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.1.RELEASE</version>
+    <version>2.1.2.RELEASE</version>
   </parent>
 
   <name>DigitalCollections: Blueprints 5: Application (Spring Boot + Commandline) (Step 02)</name>

--- a/console-application-springboot/step03/pom.xml
+++ b/console-application-springboot/step03/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.1.RELEASE</version>
+    <version>2.1.2.RELEASE</version>
   </parent>
 
   <name>DigitalCollections: Blueprints 5: Application (Spring Boot + Commandline) (Step 03)</name>

--- a/console-application-springboot/step04/pom.xml
+++ b/console-application-springboot/step04/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.1.RELEASE</version>
+    <version>2.1.2.RELEASE</version>
   </parent>
 
   <name>DigitalCollections: Blueprints 5: Application (Spring Boot + Commandline) (Step 04)</name>

--- a/webapp-springboot-thymeleaf/doc/README-01-Initial_setup_packaging_running.md
+++ b/webapp-springboot-thymeleaf/doc/README-01-Initial_setup_packaging_running.md
@@ -19,12 +19,20 @@ my-webapp
 
 ## Basic Maven project file `pom.xml`
 
-As we do not want to have Spring Boot as parent (we have another one), we modify the `pom.xml` like described here: (see <http://docs.spring.io/spring-boot/docs/current/reference/html/using-boot-build-systems.html#using-boot-maven-without-a-parent>):
+Spring Boot starter is defined as parent like described here: <https://docs.spring.io/spring-boot/docs/current/reference/html/using-boot-build-systems.html#using-boot-maven-parent-pom>.
+
+You only need to specify the desired Spring Boot version on this dependency. For all other Spring Boot starter dependencies, you can safely omit the version number:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.2.RELEASE</version>
+  </parent>
 
   <name>DigitalCollections: Blueprints 4: Webapp (Spring Boot + Thymeleaf)</name>
   <groupId>de.digitalcollections.blueprints</groupId>
@@ -39,19 +47,6 @@ As we do not want to have Spring Boot as parent (we have another one), we modify
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.1.1.RELEASE</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -74,7 +69,6 @@ As we do not want to have Spring Boot as parent (we have another one), we modify
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>2.1.1.RELEASE</version>
         <executions>
           <execution>
             <goals>
@@ -87,7 +81,6 @@ As we do not want to have Spring Boot as parent (we have another one), we modify
   </build>
 </project>
 ```
-By using spring-boot-dependencies this way you can still keep the benefit of the Spring Boot dependency management, but not the plugin management. Therefore we also had to introduce the version for the `spring-boot-maven-plugin`.
 
 The Spring Boot Maven plugin provides many convenient features:
 
@@ -112,7 +105,6 @@ In case you want to overlay/use the resulting Spring Boot JAR as dependency in a
 <plugin>
   <groupId>org.springframework.boot</groupId>
   <artifactId>spring-boot-maven-plugin</artifactId>
-  <version>2.1.1.RELEASE</version>
   <executions>
     <execution>
       <goals>

--- a/webapp-springboot-thymeleaf/step01/pom.xml
+++ b/webapp-springboot-thymeleaf/step01/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.2.RELEASE</version>
+  </parent>
+
   <name>DigitalCollections: Blueprints 4: Webapp (Spring Boot + Thymeleaf) - Step 01</name>
   <groupId>de.digitalcollections.blueprints</groupId>
   <artifactId>webapp-springboot-thymeleaf</artifactId>
@@ -14,22 +20,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-    <version.spring-boot>2.1.1.RELEASE</version.spring-boot>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -52,7 +43,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${version.spring-boot}</version>
         <executions>
           <execution>
             <goals>

--- a/webapp-springboot-thymeleaf/step02/pom.xml
+++ b/webapp-springboot-thymeleaf/step02/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.2.RELEASE</version>
+  </parent>
+
   <name>DigitalCollections: Blueprints 4: Webapp (Spring Boot + Thymeleaf) - Step 02</name>
   <groupId>de.digitalcollections.blueprints</groupId>
   <artifactId>webapp-springboot-thymeleaf</artifactId>
@@ -14,22 +20,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
-    <version.spring-boot>2.1.1.RELEASE</version.spring-boot>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -56,7 +47,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${version.spring-boot}</version>
         <executions>
           <execution>
             <goals>

--- a/webapp-springboot-thymeleaf/step03/pom.xml
+++ b/webapp-springboot-thymeleaf/step03/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.2.RELEASE</version>
+  </parent>
+
   <name>DigitalCollections: Blueprints 4: Webapp (Spring Boot + Thymeleaf) - Step 03</name>
   <groupId>de.digitalcollections.blueprints</groupId>
   <artifactId>webapp-springboot-thymeleaf</artifactId>
@@ -20,26 +26,12 @@
     <versionName>${project.version} manually built by ${user.name} at ${maven.build.timestamp}</versionName>
 
     <version.dc-commons-springboot>3.0.1</version.dc-commons-springboot>
-    <version.spring-boot>2.1.1.RELEASE</version.spring-boot>
 
     <!-- plugins -->
     <version.git-commit-id-plugin>2.2.5</version.git-commit-id-plugin>
     <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
     <version.maven-resources-plugin>3.1.0</version.maven-resources-plugin>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -96,7 +88,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${version.spring-boot}</version>
         <executions>
           <execution>
             <goals>

--- a/webapp-springboot-thymeleaf/step04/pom.xml
+++ b/webapp-springboot-thymeleaf/step04/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.2.RELEASE</version>
+  </parent>
+
   <name>DigitalCollections: Blueprints 4: Webapp (Spring Boot + Thymeleaf) - Step 04</name>
   <groupId>de.digitalcollections.blueprints</groupId>
   <artifactId>webapp-springboot-thymeleaf</artifactId>
@@ -20,26 +26,12 @@
     <versionName>${project.version} manually built by ${user.name} at ${maven.build.timestamp}</versionName>
 
     <version.dc-commons-springboot>3.0.1</version.dc-commons-springboot>
-    <version.spring-boot>2.1.1.RELEASE</version.spring-boot>
 
     <!-- plugins -->
     <version.git-commit-id-plugin>2.2.5</version.git-commit-id-plugin>
     <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
     <version.maven-resources-plugin>3.1.0</version.maven-resources-plugin>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -96,7 +88,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${version.spring-boot}</version>
         <executions>
           <execution>
             <goals>

--- a/webapp-springboot-thymeleaf/step05/pom.xml
+++ b/webapp-springboot-thymeleaf/step05/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.2.RELEASE</version>
+  </parent>
+
   <name>DigitalCollections: Blueprints 4: Webapp (Spring Boot + Thymeleaf) - Step 05</name>
   <groupId>de.digitalcollections.blueprints</groupId>
   <artifactId>webapp-springboot-thymeleaf</artifactId>
@@ -20,7 +26,6 @@
     <versionName>${project.version} manually built by ${user.name} at ${maven.build.timestamp}</versionName>
 
     <version.dc-commons-springboot>3.0.1</version.dc-commons-springboot>
-    <version.spring-boot>2.1.1.RELEASE</version.spring-boot>
     <version.webjar-bootstrap>3.3.7</version.webjar-bootstrap>
     <version.webjar-html5shiv>3.7.3</version.webjar-html5shiv>
     <version.webjar-ie10-viewport-bug-workaround>1.0.3</version.webjar-ie10-viewport-bug-workaround>
@@ -32,19 +37,6 @@
     <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
     <version.maven-resources-plugin>3.1.0</version.maven-resources-plugin>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -149,7 +141,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${version.spring-boot}</version>
         <executions>
           <execution>
             <goals>

--- a/webapp-springboot-thymeleaf/step06/pom.xml
+++ b/webapp-springboot-thymeleaf/step06/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.2.RELEASE</version>
+  </parent>
+
   <name>DigitalCollections: Blueprints 4: Webapp (Spring Boot + Thymeleaf) - Step 06</name>
   <groupId>de.digitalcollections.blueprints</groupId>
   <artifactId>webapp-springboot-thymeleaf</artifactId>
@@ -20,7 +26,6 @@
     <versionName>${project.version} manually built by ${user.name} at ${maven.build.timestamp}</versionName>
 
     <version.dc-commons-springboot>3.0.1</version.dc-commons-springboot>
-    <version.spring-boot>2.1.1.RELEASE</version.spring-boot>
     <version.webjar-bootstrap>3.3.7</version.webjar-bootstrap>
     <version.webjar-html5shiv>3.7.3</version.webjar-html5shiv>
     <version.webjar-ie10-viewport-bug-workaround>1.0.3</version.webjar-ie10-viewport-bug-workaround>
@@ -32,19 +37,6 @@
     <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
     <version.maven-resources-plugin>3.1.0</version.maven-resources-plugin>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -149,7 +141,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${version.spring-boot}</version>
         <executions>
           <execution>
             <goals>

--- a/webapp-springboot-thymeleaf/step07/pom.xml
+++ b/webapp-springboot-thymeleaf/step07/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.2.RELEASE</version>
+  </parent>
+
   <name>DigitalCollections: Blueprints 4: Webapp (Spring Boot + Thymeleaf) - Step 07</name>
   <groupId>de.digitalcollections.blueprints</groupId>
   <artifactId>webapp-springboot-thymeleaf</artifactId>
@@ -20,7 +26,6 @@
     <versionName>${project.version} manually built by ${user.name} at ${maven.build.timestamp}</versionName>
 
     <version.dc-commons-springboot>3.0.1</version.dc-commons-springboot>
-    <version.spring-boot>2.1.1.RELEASE</version.spring-boot>
     <version.webjar-bootstrap>3.3.7</version.webjar-bootstrap>
     <version.webjar-html5shiv>3.7.3</version.webjar-html5shiv>
     <version.webjar-ie10-viewport-bug-workaround>1.0.3</version.webjar-ie10-viewport-bug-workaround>
@@ -32,19 +37,6 @@
     <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
     <version.maven-resources-plugin>3.1.0</version.maven-resources-plugin>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -149,7 +141,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${version.spring-boot}</version>
         <executions>
           <execution>
             <goals>

--- a/webapp-springboot-thymeleaf/step08/pom.xml
+++ b/webapp-springboot-thymeleaf/step08/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.2.RELEASE</version>
+  </parent>
+
   <name>DigitalCollections: Blueprints 4: Webapp (Spring Boot + Thymeleaf) - Step 08</name>
   <groupId>de.digitalcollections.blueprints</groupId>
   <artifactId>webapp-springboot-thymeleaf</artifactId>
@@ -20,7 +26,6 @@
     <versionName>${project.version} manually built by ${user.name} at ${maven.build.timestamp}</versionName>
 
     <version.dc-commons-springboot>3.0.1</version.dc-commons-springboot>
-    <version.spring-boot>2.1.1.RELEASE</version.spring-boot>
     <version.webjar-bootstrap>3.3.7</version.webjar-bootstrap>
     <version.webjar-html5shiv>3.7.3</version.webjar-html5shiv>
     <version.webjar-ie10-viewport-bug-workaround>1.0.3</version.webjar-ie10-viewport-bug-workaround>
@@ -32,19 +37,6 @@
     <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
     <version.maven-resources-plugin>3.1.0</version.maven-resources-plugin>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -149,7 +141,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${version.spring-boot}</version>
         <executions>
           <execution>
             <goals>

--- a/webapp-springboot-thymeleaf/step09/pom.xml
+++ b/webapp-springboot-thymeleaf/step09/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.2.RELEASE</version>
+  </parent>
+
   <name>DigitalCollections: Blueprints 4: Webapp (Spring Boot + Thymeleaf) - Step 09</name>
   <groupId>de.digitalcollections.blueprints</groupId>
   <artifactId>webapp-springboot-thymeleaf</artifactId>
@@ -21,7 +27,6 @@
 
     <version.dc-commons-springboot>3.0.1</version.dc-commons-springboot>
     <version.javamelody-spring-boot-starter>1.74.0</version.javamelody-spring-boot-starter>
-    <version.spring-boot>2.1.1.RELEASE</version.spring-boot>
     <version.webjar-bootstrap>3.3.7</version.webjar-bootstrap>
     <version.webjar-html5shiv>3.7.3</version.webjar-html5shiv>
     <version.webjar-ie10-viewport-bug-workaround>1.0.3</version.webjar-ie10-viewport-bug-workaround>
@@ -33,19 +38,6 @@
     <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
     <version.maven-resources-plugin>3.1.0</version.maven-resources-plugin>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -168,7 +160,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${version.spring-boot}</version>
         <executions>
           <execution>
             <goals>

--- a/webapp-springboot-thymeleaf/step10/pom.xml
+++ b/webapp-springboot-thymeleaf/step10/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.2.RELEASE</version>
+  </parent>
+
   <name>DigitalCollections: Blueprints 4: Webapp (Spring Boot + Thymeleaf) - Step 10</name>
   <groupId>de.digitalcollections.blueprints</groupId>
   <artifactId>webapp-springboot-thymeleaf</artifactId>
@@ -21,7 +27,6 @@
 
     <version.dc-commons-springboot>3.0.1</version.dc-commons-springboot>
     <version.javamelody-spring-boot-starter>1.74.0</version.javamelody-spring-boot-starter>
-    <version.spring-boot>2.1.1.RELEASE</version.spring-boot>
     <version.webjar-bootstrap>3.3.7</version.webjar-bootstrap>
     <version.webjar-html5shiv>3.7.3</version.webjar-html5shiv>
     <version.webjar-ie10-viewport-bug-workaround>1.0.3</version.webjar-ie10-viewport-bug-workaround>
@@ -34,19 +39,6 @@
     <version.maven-failsafe-plugin>2.22.1</version.maven-failsafe-plugin>
     <version.maven-resources-plugin>3.1.0</version.maven-resources-plugin>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -164,7 +156,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${version.spring-boot}</version>
         <executions>
           <execution>
             <goals>

--- a/webapp-springboot-thymeleaf/step11/pom.xml
+++ b/webapp-springboot-thymeleaf/step11/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.2.RELEASE</version>
+  </parent>
+
   <name>DigitalCollections: Blueprints 4: Webapp (Spring Boot + Thymeleaf) - Step 11</name>
   <groupId>de.digitalcollections.blueprints</groupId>
   <artifactId>webapp-springboot-thymeleaf</artifactId>
@@ -21,7 +27,6 @@
 
     <version.dc-commons-springboot>3.0.1</version.dc-commons-springboot>
     <version.javamelody-spring-boot-starter>1.74.0</version.javamelody-spring-boot-starter>
-    <version.spring-boot>2.1.1.RELEASE</version.spring-boot>
     <version.webjar-bootstrap>3.3.7</version.webjar-bootstrap>
     <version.webjar-html5shiv>3.7.3</version.webjar-html5shiv>
     <version.webjar-ie10-viewport-bug-workaround>1.0.3</version.webjar-ie10-viewport-bug-workaround>
@@ -35,19 +40,6 @@
     <version.maven-resources-plugin>3.1.0</version.maven-resources-plugin>
     <version.maven-surefire-plugin>2.22.1</version.maven-surefire-plugin>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -200,7 +192,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${version.spring-boot}</version>
         <executions>
           <execution>
             <goals>

--- a/webapp-springboot-thymeleaf/step12/pom.xml
+++ b/webapp-springboot-thymeleaf/step12/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.2.RELEASE</version>
+  </parent>
+
   <name>DigitalCollections: Blueprints 4: Webapp (Spring Boot + Thymeleaf) - Step 12</name>
   <groupId>de.digitalcollections.blueprints</groupId>
   <artifactId>webapp-springboot-thymeleaf</artifactId>
@@ -21,7 +27,6 @@
 
     <version.dc-commons-springboot>3.0.1</version.dc-commons-springboot>
     <version.javamelody-spring-boot-starter>1.75.0</version.javamelody-spring-boot-starter>
-    <version.spring-boot>2.1.1.RELEASE</version.spring-boot>
     <version.webjar-bootstrap>4.2.1</version.webjar-bootstrap>
     <version.webjar-html5shiv>3.7.3</version.webjar-html5shiv>
     <version.webjar-ie10-viewport-bug-workaround>1.0.3</version.webjar-ie10-viewport-bug-workaround>
@@ -35,19 +40,6 @@
     <version.maven-resources-plugin>3.1.0</version.maven-resources-plugin>
     <version.maven-surefire-plugin>2.22.1</version.maven-surefire-plugin>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -203,7 +195,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${version.spring-boot}</version>
         <executions>
           <execution>
             <goals>

--- a/webapp-springboot-thymeleaf/step13/pom.xml
+++ b/webapp-springboot-thymeleaf/step13/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.2.RELEASE</version>
+  </parent>
+
   <name>DigitalCollections: Blueprints 4: Webapp (Spring Boot + Thymeleaf) - Step 13</name>
   <groupId>de.digitalcollections.blueprints</groupId>
   <artifactId>webapp-springboot-thymeleaf</artifactId>
@@ -22,7 +28,6 @@
     <version.dc-commons-springboot>3.0.1</version.dc-commons-springboot>
     <version.embedded-redis>0.7.2</version.embedded-redis>
     <version.javamelody-spring-boot-starter>1.74.0</version.javamelody-spring-boot-starter>
-    <version.spring-boot>2.1.1.RELEASE</version.spring-boot>
     <version.webjar-bootstrap>4.2.1</version.webjar-bootstrap>
     <version.webjar-html5shiv>3.7.3</version.webjar-html5shiv>
     <version.webjar-ie10-viewport-bug-workaround>1.0.3</version.webjar-ie10-viewport-bug-workaround>
@@ -36,19 +41,6 @@
     <version.maven-resources-plugin>3.1.0</version.maven-resources-plugin>
     <version.maven-surefire-plugin>2.22.1</version.maven-surefire-plugin>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -218,7 +210,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${version.spring-boot}</version>
         <executions>
           <execution>
             <goals>

--- a/webapp-springboot-thymeleaf/step14/pom.xml
+++ b/webapp-springboot-thymeleaf/step14/pom.xml
@@ -2,6 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.1.2.RELEASE</version>
+  </parent>
+
   <name>DigitalCollections: Blueprints 4: Webapp (Spring Boot + Thymeleaf) - Step 14</name>
   <groupId>de.digitalcollections.blueprints</groupId>
   <artifactId>webapp-springboot-thymeleaf</artifactId>
@@ -22,7 +28,6 @@
     <version.dc-commons-springboot>3.0.1</version.dc-commons-springboot>
     <version.embedded-redis>0.7.2</version.embedded-redis>
     <version.javamelody-spring-boot-starter>1.74.0</version.javamelody-spring-boot-starter>
-    <version.spring-boot>2.1.1.RELEASE</version.spring-boot>
     <version.webjar-bootstrap>4.2.1</version.webjar-bootstrap>
     <version.webjar-html5shiv>3.7.3</version.webjar-html5shiv>
     <version.webjar-ie10-viewport-bug-workaround>1.0.3</version.webjar-ie10-viewport-bug-workaround>
@@ -39,19 +44,6 @@
     <version.spotbugs>3.1.9</version.spotbugs>
     <version.spotbugs-maven-plugin>3.1.8</version.spotbugs-maven-plugin>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -255,7 +247,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${version.spring-boot}</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
instead of using Spring Boot starter dependencies as BOM in `<dependencyManagement>` (which won't allow us to override specific versions of dependencies), the Spring Boot starter dependencies are added to the  `<parent>` section.

Fixes #34.